### PR TITLE
Crash dumps now only made if 86box is actually about to crash

### DIFF
--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -19,7 +19,7 @@ OBJ = 386.o 386_dynarec.o 386_dynarec_ops.o 808x.o acer386sx.o acerm3a.o ali1429
 	vid_olivetti_m24.o vid_oti067.o vid_paradise.o vid_pc1512.o vid_pc1640.o vid_pc200.o \
 	vid_pcjr.o vid_ps1_svga.o vid_s3.o vid_s3_virge.o vid_sdac_ramdac.o vid_stg_ramdac.o vid_svga.o \
 	vid_svga_render.o vid_tandy.o vid_tandysl.o vid_tgui9440.o vid_tkd8001_ramdac.o vid_tvga.o vid_unk_ramdac.o \
-	vid_vga.o vid_wy700.o vid_voodoo.o video.o w83877f.o wd76c10.o win.o win-config.o win-d3d.o win-d3d-fs.o win-ddraw.o \
+	vid_vga.o vid_wy700.o vid_voodoo.o video.o w83877f.o wd76c10.o win.o win-crashdump.o win-config.o win-d3d.o win-d3d-fs.o win-ddraw.o \
 	win-ddraw-fs.o win-ddraw-screenshot.o win-deviceconfig.o win-hdconf.o win-joystick.o win-joystickconfig.o win-keyboard.o win-midi.o win-mouse.o \
 	win-status.o win-video.o x86seg.o x87.o xtide.o pc.res
 DBOBJ = dbopl.o nukedopl.o vid_cga_comp.o

--- a/src/Makefile.mingw64
+++ b/src/Makefile.mingw64
@@ -19,7 +19,7 @@ OBJ = 386.o 386_dynarec.o 386_dynarec_ops.o 808x.o acer386sx.o acerm3a.o ali1429
 	vid_olivetti_m24.o vid_oti067.o vid_paradise.o vid_pc1512.o vid_pc1640.o vid_pc200.o \
 	vid_pcjr.o vid_ps1_svga.o vid_s3.o vid_s3_virge.o vid_sdac_ramdac.o vid_stg_ramdac.o vid_svga.o \
 	vid_svga_render.o vid_tandy.o vid_tandysl.o vid_tgui9440.o vid_tkd8001_ramdac.o vid_tvga.o vid_unk_ramdac.o \
-	vid_vga.o vid_wy700.o vid_voodoo.o video.o w83877f.o wd76c10.o win.o win-config.o win-d3d.o win-d3d-fs.o win-ddraw.o \
+	vid_vga.o vid_wy700.o vid_voodoo.o video.o w83877f.o wd76c10.o win.o win-crashdump.o win-config.o win-d3d.o win-d3d-fs.o win-ddraw.o \
 	win-ddraw-fs.o win-ddraw-screenshot.o win-deviceconfig.o win-hdconf.o win-joystick.o win-joystickconfig.o win-keyboard.o win-midi.o win-mouse.o \
 	win-status.o win-video.o x86seg.o x87.o xtide.o pc.res
 DBOBJ = dbopl.o nukedopl.o vid_cga_comp.o

--- a/src/win-crashdump.c
+++ b/src/win-crashdump.c
@@ -19,6 +19,12 @@ LONG CALLBACK MakeCrashDump(PEXCEPTION_POINTERS ExceptionInfo) {
 	// Win32-specific functions will be used wherever possible, just in case the C stdlib-equivalents try to allocate memory.
 	// (The Win32-specific functions are generally just wrappers over NT system calls anyway.)
 	
+	if ((ExceptionInfo->ExceptionRecord->ExceptionCode >> 28) != 0xC) {
+		// The exception code is not a fatal exception (highest 4 bits of ntstatus = 0xC)
+		// Not going to crash, let's not make a crash dump
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+	
 	// So, the program is about to crash. Oh no what do?
 	// Let's create a crash dump file as a debugging-aid.
 	

--- a/src/win-crashdump.c
+++ b/src/win-crashdump.c
@@ -1,0 +1,114 @@
+/* Copyright holders: Riley
+   see COPYING for more details
+   
+   win-crashdump.c : Windows exception handler to make a crash dump just before a crash happens.
+*/
+#define _WIN32_WINNT 0x0501
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "86box.h"
+#include "win-crashdump.h"
+
+PVOID hExceptionHandler;
+char* ExceptionHandlerBuffer;
+
+
+LONG CALLBACK MakeCrashDump(PEXCEPTION_POINTERS ExceptionInfo) {
+	// Win32-specific functions will be used wherever possible, just in case the C stdlib-equivalents try to allocate memory.
+	// (The Win32-specific functions are generally just wrappers over NT system calls anyway.)
+	
+	// So, the program is about to crash. Oh no what do?
+	// Let's create a crash dump file as a debugging-aid.
+	
+	// First, what would a good filename be? It should contain the current date and time so as to be (hopefully!) unique.
+	SYSTEMTIME SystemTime;
+	GetSystemTime(&SystemTime);
+	sprintf(ExceptionHandlerBuffer,
+		"86box-%d%02d%02d-%02d-%02d-%02d-%03d.dmp",
+		SystemTime.wYear,
+		SystemTime.wMonth,
+		SystemTime.wDay,
+		SystemTime.wHour,
+		SystemTime.wMinute,
+		SystemTime.wSecond,
+		SystemTime.wMilliseconds);
+	
+	DWORD Error;
+	
+	// Now the filename is in the buffer, the file can be created.
+	HANDLE hDumpFile = CreateFile(
+		ExceptionHandlerBuffer, // The filename of the file to open.
+		GENERIC_WRITE, // The permissions to request.
+		0, // Make sure other processes can't touch the crash dump at all while it's open.
+		NULL, // Leave the security descriptor undefined, it doesn't matter.
+		OPEN_ALWAYS, // Opens the file if it exists, creates a new file if it doesn't.
+		FILE_ATTRIBUTE_NORMAL, // File attributes / etc don't matter.
+		NULL); // A template file is not being used.
+	
+	// Check to make sure the file was actually created.
+	if (hDumpFile == INVALID_HANDLE_VALUE) {
+		// CreateFile() failed, so just do nothing more.
+		return EXCEPTION_CONTINUE_SEARCH;
+	}
+	
+	// Now the file is open, let's write the data we were passed out in a human-readable format.
+	
+	sprintf(ExceptionHandlerBuffer,
+		"86Box version %s crashed on %d-%02d-%02d %02d:%02d:%02d.%03d\r\n\r\n"
+		""
+		"Exception details:\r\n"
+		"Exception NTSTATUS code: 0x%08x\r\n"
+		"Occured at address: 0x%p\r\n"
+		"Number of parameters: %d\r\n"
+		"Exception parameters: ",
+		emulator_version, SystemTime.wYear, SystemTime.wMonth, SystemTime.wDay, SystemTime.wHour, SystemTime.wMinute, SystemTime.wSecond, SystemTime.wMilliseconds,
+		
+		ExceptionInfo->ExceptionRecord->ExceptionCode,
+		ExceptionInfo->ExceptionRecord->ExceptionAddress,
+		ExceptionInfo->ExceptionRecord->NumberParameters);
+	
+	char* CurrentBufferPointer;
+	
+	for (int i = 0; i < ExceptionInfo->ExceptionRecord->NumberParameters; i++) {
+		CurrentBufferPointer = &ExceptionHandlerBuffer[strlen(ExceptionHandlerBuffer)];
+		sprintf(CurrentBufferPointer,"0x%p ",ExceptionInfo->ExceptionRecord->ExceptionInformation[i]);
+	}
+	
+	CurrentBufferPointer = &ExceptionHandlerBuffer[strlen(ExceptionHandlerBuffer) - 1];
+	
+	PCONTEXT Registers = ExceptionInfo->ContextRecord;
+	
+	#if defined(__i386__) && !defined(__x86_64)
+	sprintf(CurrentBufferPointer,
+		"\r\n"
+		"Register dump:\r\n"
+		"eax=0x%08x ebx=0x%08x ecx=0x%08x edx=0x%08x ebp=0x%08x esp=0x%08x esi=0x%08x edi=0x%08x eip=0x%08x\r\n"
+		"\r\n",
+		Registers->Eax, Registers->Ebx, Registers->Ecx, Registers->Edx, Registers->Ebp, Registers->Esp, Registers->Esi, Registers->Edi, Registers->Eip);
+	#else
+	// Register dump is supported by no other architectures right now. MinGW headers seem to lack the x64 CONTEXT structure definition.
+	sprintf(CurrentBufferPointer,"\r\n");
+	#endif
+	
+	WriteFile(hDumpFile,
+		ExceptionHandlerBuffer,
+		strlen(ExceptionHandlerBuffer),
+		NULL,
+		NULL);
+	
+	// Finally, close the file.
+	CloseHandle(hDumpFile);
+	
+	// And return, therefore causing the crash, but only after the crash dump has been created.
+	
+	return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void InitCrashDump() {
+	// An exception handler should not allocate memory, so allocate 10kb for it to use if it gets called, an amount which should be more than enough.
+	ExceptionHandlerBuffer = malloc(10240);
+	// Register the exception handler. Zero first argument means this exception handler gets called last, therefore, crash dump is only made, when a crash is going to happen.
+	hExceptionHandler = AddVectoredExceptionHandler(0,MakeCrashDump);
+}

--- a/src/win-crashdump.h
+++ b/src/win-crashdump.h
@@ -1,0 +1,7 @@
+/* Copyright holders: Riley
+   see COPYING for more details
+   
+   win-crashdump.c : Windows crash dump exception handler header file.
+*/
+
+void InitCrashDump();

--- a/src/win.c
+++ b/src/win.c
@@ -44,6 +44,7 @@
 #include "win-d3d.h"
 #include "win-d3d-fs.h"
 //#include "win-opengl.h"
+#include "win-crashdump.h"
 
 #ifndef MAPVK_VK_TO_VSC
 #define MAPVK_VK_TO_VSC 0
@@ -556,6 +557,8 @@ int WINAPI WinMain (HINSTANCE hThisInstance,
 		char emulator_title[200];
         LARGE_INTEGER qpc_freq;
         HACCEL haccel;           /* Handle to accelerator table */
+		
+		InitCrashDump(); // First thing to do before anything else is to make sure crash dumps get created.
 
         process_command_line();
         


### PR DESCRIPTION
Fixes 3 crash dumps being made when a file open dialog is created